### PR TITLE
Make no-invoker synonymous with generic

### DIFF
--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -158,8 +158,7 @@ void ExecPrivate::trigger(bool) const
         LCA_WARNING << "cannot trigger: " << error->message;
         g_error_free(error);
     }
-    g_list_foreach(uris, (GFunc)g_free, NULL);
-    g_list_free(uris);
+    g_list_free_full(uris, g_free);
 }
 
 } // end namespace ContentAction


### PR DESCRIPTION
After this change all apps will go through booster. Generic booster
should not differ much from launching directly but this way we can
better control for example sandboxing.

Also fix a build warning.