### PR TITLE
[libcontentaction] Fix unit test failure on mime type string. Fixes JB#61528

### DIFF
--- a/tests/test-info.cpp
+++ b/tests/test-info.cpp
@@ -4,58 +4,39 @@
 
 #include <contentinfo.h>
 
-void
-dump_info (ContentInfo &info)
-{
-  if (info.isValid())
-    {
-      qDebug() << "mime:" << info.mimeType();
-      qDebug() << "desc:" << info.typeDescription();
-      qDebug() << "icon:" << info.typeIcon();
-    }
-  else
-    qDebug() << "invalid";
-}
-
 class TestInfo : public QObject
 {
   Q_OBJECT
 
 private Q_SLOTS:
-  
-  void
-  test_mime_info ()
-  {
-    ContentInfo info = ContentInfo::forMime ("text/plain");
-    
-    QVERIFY(info.isValid());
-    QCOMPARE(info.mimeType(), QString::fromLatin1("text/plain"));
-    QCOMPARE(info.typeDescription(), QString::fromLatin1("plain text document"));
-  }
+    void test_mime_info()
+    {
+        ContentInfo info = ContentInfo::forMime ("text/plain");
 
-  void
-  test_file_info ()
-  {
-    ContentInfo info = ContentInfo::forFile (QUrl::fromLocalFile(QDir::currentPath() + "/test-image.png"));
-    
-    QVERIFY(info.isValid());
-    QCOMPARE(info.mimeType(), QString::fromLatin1("image/png"));
-    QCOMPARE(info.typeDescription(), QString::fromLatin1("PNG image"));
-  }
+        QVERIFY(info.isValid());
+        QCOMPARE(info.mimeType(), QString::fromLatin1("text/plain"));
+        QCOMPARE(info.typeDescription(), QString::fromLatin1("Plain text document"));
+    }
 
-  void
-  test_bytes_info ()
-  {
-    QFile file("./test-image.png");
-    file.open (QIODevice::ReadOnly);
-    QByteArray content = file.read (200);
-    
-    ContentInfo info = ContentInfo::forData (content);
-    
-    QVERIFY(info.isValid());
-    QCOMPARE(info.mimeType(), QString::fromLatin1("image/png"));
-    QCOMPARE(info.typeDescription(), QString::fromLatin1("PNG image"));
-  }
+    void test_file_info() {
+        ContentInfo info = ContentInfo::forFile (QUrl::fromLocalFile(QDir::currentPath() + "/test-image.png"));
+
+        QVERIFY(info.isValid());
+        QCOMPARE(info.mimeType(), QString::fromLatin1("image/png"));
+        QCOMPARE(info.typeDescription(), QString::fromLatin1("PNG image"));
+    }
+
+    void test_bytes_info() {
+        QFile file("./test-image.png");
+        file.open (QIODevice::ReadOnly);
+        QByteArray content = file.read (200);
+
+        ContentInfo info = ContentInfo::forData (content);
+
+        QVERIFY(info.isValid());
+        QCOMPARE(info.mimeType(), QString::fromLatin1("image/png"));
+        QCOMPARE(info.typeDescription(), QString::fromLatin1("PNG image"));
+    }
 };
 
 QTEST_MAIN(TestInfo);


### PR DESCRIPTION
Shared-mime-info changed to capital strings.
Also reformatted the test file for more common style.

Shared-mime-info change:

commit 1931043b3896745105ea6695624b342f482c4093
Author: Peter Eisenmann <p3732@getgoogleoff.me>
Date:   Thu Aug 24 00:47:32 2023 +0200

    use Sentence case for mime type descriptions